### PR TITLE
Add the authentication functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,8 @@ name: Calibre
 
 on:
   push:
-    tags:
-      - '*'
-    paths:
-      - './Dockerfile'
+    branches:
+      - 'main'
 
   workflow_dispatch:
 
@@ -32,6 +30,8 @@ jobs:
   build:
     needs: [security-check]
     runs-on: ubuntu-latest
+    env:
+      TAG_NAME: 5.34.0
     environment:
       name: calibre
     steps:
@@ -46,19 +46,15 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Set application version based on the tag
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/amd64, linux/arm64, linux/arm/v7
-          build-args: CALIBRE_RELEASE=${{ steps.vars.outputs.tag }}
           push: true
           tags: |
             lucapisciotta/calibre:latest
-            lucapisciotta/calibre:${{ steps.vars.outputs.tag }}
+            lucapisciotta/calibre:${{ env.TAG_NAME }}
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
-ARG CALIBRE_RELEASE=5.34.0
+ARG ADMIN_PASSWORD="ChangeMe!"
+ARG ENABLE_AUTH=false
 ARG TZ=Europe/Rome
-ENV CALIBRE_RELEASE=${CALIBRE_RELEASE}
-ENV TZ=${TZ}
+ENV ADMIN_PASSWORD=${ADMIN_PASSWORD}
 ENV DEBIAN_FRONTEND=noninteractive
+ENV ENABLE_AUTH=${ENABLE_AUTH}
+ENV TZ=${TZ}
 
 WORKDIR /srv
 
@@ -15,75 +17,17 @@ RUN set -euv\
     ; apt-get update \
     ; apt-get upgrade -y \
     ; apt-get install -y --no-install-recommends \
-        bash-completion \
-        build-essential \
-        ca-certificates \
         curl \
-        glibc-source \
-        libnss-mdns \
-        libfreetype-dev \
-        libhunspell-dev \
-        libhyphen-dev \
-        libicu-dev \
-        libmtp-dev \
-        libpodofo-dev \
-        libpodofo-utils \
-        libqt5charts5-dev \
-        libsqlite3-dev \
-        libstemmer-dev \
-        libusb-1.0-0-dev \
-        libusb-dev \
-        pkg-config \
-        pyqt5-dev \
-        python3 \
-        python3-apsw \
-        python3-bs4 \
-        python3-css-parser \
-        python3-hunspell \
-        python3-lxml \
-        python3-msgpack \
-        python3-regex \
-        python3-dev \
-        python3-dateutil \
-        python3-distutils \
-        python3-html5-parser \
-        python3-pil \
-        python3-pyqt5 \
-        python3-pyqtbuild \
-        python3-sipbuild \
-        qconf \
-        qt5-qmake \
-        qt5-qmake-bin \
-        qtbase5-dev \
-        qtbase5-dev-tools \
-        qtbase5-private-dev \
-        qtchooser \
-        xdg-utils \
-        xz-utils \
-    ; ln -s /usr/bin/python3 /usr/bin/python \
-    ; curl -sL https://bootstrap.pypa.io/get-pip.py -o get-pyp.py \
-    ; python get-pyp.py \
-    ; pip install -U --no-cache-dir \
-        zeroconf \
-    ; curl -L https://github.com/kovidgoyal/calibre/releases/download/v$CALIBRE_RELEASE/calibre-$CALIBRE_RELEASE.tar.xz | tar xvJ \
-    ; python3 ./calibre*/setup.py install \
-    ; rm -rf /srv/* \
+        calibre \
     ; curl -sLk -o /books/christmascarol.mobi http://www.gutenberg.org/ebooks/46.kindle.noimages \
     ; calibredb add /books/*.mobi --with-library /books \
-    ; apt-get purge -y \
-        *-dev \
-        bash-completion \
-        build-essential \
-        pkg-config \
-        qconf \
-        qt5-qmake \
-        qt5-qmake-bin \
-        qtbase5-dev-tools \
     ; apt-get clean \
     ; rm -rf /var/lib/apt/lists/* \
     ; rm -rf /var/cache/apt \
     ;
 
+COPY entrypoint.sh /srv/
+
 EXPOSE 8085
 
-ENTRYPOINT [ "/usr/bin/calibre-server", "--port=8085", "--enable-local-write", "--log=/dev/stdout", "--access-log=/dev/stdout", "--trusted-ips=192.168.0.0/16,172.16.0.0/12,10.0.0.0/8", "/books" ]
+ENTRYPOINT [ "/srv/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Initially, you can try this image without an existing library because I've added
 
 I've enabled the function to add new ebooks directly from the WebUI but this is available only from the same local network (With an IP in these subnets `192.168.0.0/16`, `172.16.0.0/12` and `10.0.0.0/8`)
 
+If you need to enable the authentication you can simply add `ENABLE_AUTH=true` in the environemnt variables and pass your users database as a volume that point to `/srv/calibre/users.sqlite`.
+If you want to try the authentication system you can simply add the variable and pass `ADMIN_PASSWORD=yourpassword` to the container or use the default password which is `ChangeMe!`.
+
 ### Usage
 ------------------------
 Here are some example snippets to help you get started creating a container.
@@ -40,9 +43,12 @@ services:
         image: lucapisciotta/calibre
         container_name: calibre
         environment:
+            - ADMIN_PASSWORD=yourpassword  # Optional, you need to add it only if you want to change the default password in the example database.
+            - ENABLE_AUTH=true  # Optional, you need to add it only if you need the authentication.
             - TZ=Europe/Rome
         volumes:
             - /path/to/calibre/library:/books
+            - /path/to/your/users/database:/srv/calibre/users.sqlite  # Optional, you need to add it only if you want to pass your custom users database
         ports:
             - 8085:8085
         restart: unless-stopped
@@ -51,9 +57,12 @@ services:
 ```
 docker run -d \
     --name=calibre \
+    -e ADMIN_PASSWORD=yourpassword  \  # Optional, you need to add it only if you want to change the default password in the example database.
+    -e ENABLE_AUTH=true  \  # Optional, you need to add it only if you need the authentication
     -e TZ=Europe/Rome \
     -p 8085:8085 \
     -v /path/to/calibre/library:/books \
+    -v /path/to/your/users/database:/srv/calibre/users.sqlite \  # Optional, you need to add it only if you want to pass your custom users database
     --restart unless-stopped \
     lucapisciotta/calibre
 ```
@@ -62,9 +71,13 @@ docker run -d \
 Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate <external>:<internal> respectively. For example, -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080 outside the container.
 | Parameter | Function |
 | :---: | :---: |
-|`-p 8085:8085` | WebUI |
-|`-e TZ=Europe/Rome` | Specify a timezone to use EG Europe/Rome. |
-|`-v /books` | Where your preexisting calibre database is located. |
+| `-p 8085:8085` | WebUI |
+| `-e ADMIN_PASSWORD=yourpassword` | **Optional** - You need to add it only if you want to change the default password in the example database. |
+| `-e ENABLE_AUTH` | **Optional** -  you need to add it only if you need the authentication. |
+| `-e TZ=Europe/Rome` | Specify a timezone to use Europe/Rome or the timezone that you prefer. |
+| `-v /path/to/calibre/library:/books` | Where your preexisting calibre database is located. |
+| `-v /path/to/your/users/database:/srv/calibre/users.sqlite` | **Optional** - you need to add it only if you want to pass your custom users database|
+
 
 ### Sources
 ------------------------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+function create_user_db {
+    /usr/bin/calibre-server \
+    --userdb /srv/calibre/users.sqlite \
+    --manage-users add admin "${ADMIN_PASSWORD}"
+}
+
+if "${ENABLE_AUTH}"; then
+    if [ -f /srv/calibre/users.sqlite ]; then
+        /usr/bin/calibre-server \
+            --enable-auth \
+            --userdb /srv/calibre/users.sqlite \
+            --port=8085 \
+            --enable-local-write \
+            --log=/dev/stdout \
+            --access-log=/dev/stdout \
+            --trusted-ips=192.168.0.0/16,172.16.0.0/12,10.0.0.0/8 \
+            /books
+    else
+        create_user_db
+        /usr/bin/calibre-server \
+            --enable-auth \
+            --userdb /srv/calibre/users.sqlite \
+            --port=8085 \
+            --enable-local-write \
+            --log=/dev/stdout \
+            --access-log=/dev/stdout \
+            --trusted-ips=192.168.0.0/16,172.16.0.0/12,10.0.0.0/8 \
+            /books
+    fi
+else
+    /usr/bin/calibre-server \
+        --port=8085 \
+        --enable-local-write \
+        --log=/dev/stdout \
+        --access-log=/dev/stdout \
+        --trusted-ips=192.168.0.0/16,172.16.0.0/12,10.0.0.0/8 \
+        /books
+fi


### PR DESCRIPTION
- Change the base image from `ubuntu:21.04` to `ubuntu:22.04`
- Remove the building of the calibre package and add the use of the official repository package
- Added `entrypoint.sh` to manage the authentication system
- Fix the GitHub action to start on push in the `main` branch
- Updated `README.md`

resolves #2